### PR TITLE
Material design update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ component aims to be a clone of the time picker introduced in Android Lollipop.
 
 ![wide picker screenshot][wide] ![narrow picker screenshot][narrow]
 
-See the [component page](http://bendavis78.github.io/paper-time-picker/) for 
+See the [component page](http://bendavis78.github.io/paper-time-picker/) for
 full documentation.
 
 ## Examples:
@@ -28,13 +28,13 @@ If you include this element as part of `paper-dialog`, use the class
 `"paper-time-picker-dialog"` on the dialog in order to give it proper styling.
 
 ```html
-<paper-action-dialog id="dialog" modal class="paper-time-picker-dialog">
+<paper-dialog id="dialog" modal class="paper-time-picker-dialog">
   <paper-time-picker id="timePicker"></paper-time-picker>
   <div class="buttons">
     <paper-button dialog-dismiss>Cancel</paper-button>
     <paper-button dialog-confirm>OK</paper-button>
   </div>
-</paper-action-dialog>
+</paper-dialog>
 ```
 
 ---

--- a/paper-time-picker.css
+++ b/paper-time-picker.css
@@ -28,12 +28,12 @@
   width: 520px;
   height: 240px;
 }
-#heading { 
+#heading {
   width: 270px;
   height: 240px;
   @apply(--layout-horizontal);
   @apply(--layout-center);
-  @apply(--layout-center-justified);
+  @apply(--layout-end-justified);
 }
 #clockArea {
   margin: 12px 22px;
@@ -44,7 +44,7 @@
 /** Narrow *********************/
 :host([narrow]) {
   width: 270px;
-  height: 366px;
+  height: 346px;
 }
 :host([narrow]) #heading {
   height: 96px;
@@ -58,26 +58,26 @@
   color: var(--light-primary-color);
   background: var(--default-primary-color);
 }
-#heading .time {
-  font-size: 0;
-  width: 200px;
-  text-align: right;
-}
-#heading .time .iron-selected {
+#heading .iron-selected {
   color: var(--text-primary-color);
 }
-#heading .time .period {
-  @apply(--paper-font-title);
-  padding-left: 4px;
-  line-height: 33px !important;
-}
-#heading .time div {
-  @apply(--paper-font-display3);
-  display: inline-block;
-  padding: 2px;
-}
-#heading .time div:hover {
+#heading iron-selector:hover {
   cursor: pointer;
+}
+
+#heading .time span {
+  @apply(--paper-font-display3);
+}
+
+/** Period selector *************/
+#periodSelector {
+  margin-left: 16px;
+  margin-right: 32px;
+  @apply(--layout-vertical);
+  @apply(--layout-justified);
+}
+#periodSelector .period {
+  line-height: 25px;
 }
 
 /** Clock *********************/
@@ -87,7 +87,7 @@
 #selectors {
   pointer-events: none;
 }
-#selectors, 
+#selectors,
 #selectors > section,
 #selectors > section > * {
   @apply(--layout-fit);
@@ -100,29 +100,6 @@
   z-index: 0;
 }
 
-/** Period selector *************/
-#periodSelector {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 38px;
-  @apply(--layout-horizontal);
-  @apply(--layout-justified);
-}
-#periodSelector .period {
-  cursor: pointer;
-  width: 36px;
-  height: 36px;
-  line-height: 38px;
-  border-radius: 100%;
-  text-align: center;
-  vertical-align: middle;
-}
-#periodSelector .period.iron-selected {
-  background: var(--default-primary-color);
-  color: var(--text-primary-color);
-}
 
 /** Clock transition ***********/
 #selectors .iron-selected /deep/ #clock .face {

--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -61,17 +61,16 @@ If you include this element as part of `paper-dialog`, use the class
     <div id="timePicker">
       <div id="heading">
         <iron-selector class="time" id="timeParts" selectable="[name]" attr-for-selected="name" selected="{{_page}}">
-          <div name="hour" class="hour">{{_twelveHour(hour)}}</div>
-          <div class="sep">:</div>
-          <div name="minute" class="minute">{{_zeroPad(minute, 2)}}</div>
-          <div class="period" self-end on-tap="togglePeriod">{{period}}</div>
+          <span name="hour" class="hour">[[_twelveHour(hour)]]</span>
+          <span class="sep">:</span>
+          <span name="minute" class="minute">[[_zeroPad(minute, 2)]]</span>
         </iron-selector>
-      </div>
-      <div id="clockArea">
-        <iron-selector id="periodSelector" selected="{{period}}" attr-for-selected="name">
+        <iron-selector id="periodSelector" selected="{{period}}" attr-for-selected="name" selectable="[name]">
           <div class="period" name="AM">AM</div>
           <div class="period" name="PM">PM</div>
         </iron-selector>
+      </div>
+      <div id="clockArea">
         <iron-selector id="selectors" selected="{{_page}}" attr-for-selected="name" activate-event="">
           <section name="hour" id$="selectHour">
             <paper-clock-selector id="hourSelector" count="12" selected="{{hour12}}"></paper-clock-selector>

--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -26,13 +26,13 @@ Setting the initial time to 4:20pm (note that hours given as 24-hour):
 If you include this element as part of `paper-dialog`, use the class
 `"paper-time-picker-dialog"` on the dialog in order to give it proper styling.
 
-    <paper-action-dialog id="dialog" modal class="paper-time-picker-dialog">
+    <paper-dialog id="dialog" modal class="paper-time-picker-dialog">
       <paper-time-picker id="timePicker"></paper-time-picker>
       <div class="buttons">
         <paper-button dialog-dismiss>Cancel</paper-button>
         <paper-button dialog-confirm>OK</paper-button>
       </div>
-    </paper-action-dialog>
+    </paper-dialog>
 
 @element paper-time-picker
 @blurb Provides a responsive time picker based on the material design spec.
@@ -74,7 +74,7 @@ If you include this element as part of `paper-dialog`, use the class
         </iron-selector>
         <iron-selector id="selectors" selected="{{_page}}" attr-for-selected="name" activate-event="">
           <section name="hour" id$="selectHour">
-            <paper-clock-selector id="hourSelector" count="12" selected="{{hour12}}"></paper-clock-selector> 
+            <paper-clock-selector id="hourSelector" count="12" selected="{{hour12}}"></paper-clock-selector>
           </section>
           <section name="minute" id$="selectMinute">
             <paper-clock-selector id="minuteSelector" count="60" selected="{{minute}}" zero-pad use-zero></paper-clock-selector>


### PR DESCRIPTION
Moved the AM/PM Selector to beside the time as per the [spec](http://www.google.com/design/spec/components/pickers.html#pickers-time-pickers). 

It doesn't float beneath the time in horizontal mode but that would entail much more work, and one should probably do the spacing and everything at the same time.
