### PR TITLE
Added optional property to continously toggle between hour/minute selectors

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -36,7 +36,7 @@
       <h1>{{time}}</h1>
       <paper-button class="btn" on-tap="showDialog" raised>Change Time</paper-button>
       <paper-dialog id="dialog" class="paper-time-picker-dialog" modal>
-        <paper-time-picker id="picker" time="[[time]]"></paper-time-picker>
+        <paper-time-picker id="picker" time="[[time]]" continuous-select="true"></paper-time-picker>
         <div class="buttons">
           <paper-button dialog-dismiss>CANCEL</paper-button>
           <paper-button dialog-confirm on-tap="timeSelected">OK</paper-button>

--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -150,6 +150,10 @@ If you include this element as part of `paper-dialog`, use the class
             observer: '_periodChanged',
             value: 'AM'
           },
+		  continuousSelect : {
+		    type : Boolean,
+		    value : false
+		  },
           _queryMatches: {
             type: Boolean,
             value: false,
@@ -273,7 +277,11 @@ If you include this element as part of `paper-dialog`, use the class
           } else {
             this.minute = e.detail.value;
           }
-          this._page = 'minute';
+  		  if (this.continuousSelect) {
+		  	  this._page = (this._page == 'minute') ? 'hour' : 'minute';
+		  } else {
+			  this._page = 'minute';
+		  }
         }
       });
     })();


### PR DESCRIPTION
Setting the attribute 'continousSelect' will cause the picker to cycle between the hour and minute pages in a loop, instead of advancing once from the hour page to the minute page.
