### PR TITLE
fix parsing of clock face numbers from path for polymer version 1.2.0

### DIFF
--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -153,7 +153,10 @@
         },
         _updateNumber: function(change) {
           var parts = change.path.split('.');
-          var idx = parseInt(parts[1]);
+          if(!parts || !parts[1]) {
+            return;
+          }
+          var idx = parseInt(parts[1].substr(1), 10);
           if (isNaN(idx)) {
             return;
           }


### PR DESCRIPTION
Polymer version  1.2 changed their path handling and are now prepending a '#'
to the number part of the path. This is the Polymer change that broke it:

https://github.com/Polymer/polymer/commit/10021cc51c3f2bb113039d80e6ad1fd35e3f4ed
