### PR TITLE
If a user selected the same hour, the minute clock shows.

### DIFF
--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -468,7 +468,12 @@ If you include this element as part of `paper-dialog`, use the class
               showMinutes();
             }
 
-            this.hour12 = event.detail.value;
+            if (this.hour12 !== event.detail.value) {
+              this.hour12 = event.detail.value;
+            } else {
+              // show minutes if same hour is selected
+              showMinutes();
+            }
           }
         },
         _resizeHandler: function() {


### PR DESCRIPTION
I believe this is a design/behavior flaw in the element. Currently, the if a user selected the same hour on the paper-clock-selector, the element doesn't switch to 'minutes' mode, but it should. 

P.S. Thank you for all the work on the element. :)
