### PR TITLE
Changing imports for flex-layout and paper-style

### DIFF
--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -2,8 +2,8 @@
 <link rel="import" href="../iron-media-query/iron-media-query.html">
 <link rel="import" href="../iron-resizable/iron-resizable-behavior.html">
 <link rel="import" href="../iron-selector/iron-selector.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../neon-animation/neon-animated-pages.html">
 <link rel="import" href="../neon-animation/neon-animatable.html">
 <link rel="import" href="../neon-animation/animations/fade-in-animation.html">


### PR DESCRIPTION
I'm purposing this pull request because:
- The element is importing iron-flex-layout-classes while it is not using the classes at all. However, it is using iron-flex-vars, so I included iron-flex-layout instead.
- The element is importing paper-styles but it only uses some styling definitions from the typography module. The paper-styles import is also importing a deprecated iron-flex-classes that are causing warnings in the console (see issue PolymerElements/paper-styles#105). By importing the specific styling modules, those warnings can be circumvented.

I tested the changes and everything seems still displayed correctly.
