### PR TITLE
Fix inconsistent import of iron-resizable-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "iron-media-query": "PolymerElements/iron-media-query#^1.0.0",
     "iron-selector": "PolymerElements/iron-selector#^1.0.0",
     "neon-animation": "PolymerElements/neon-animation#^1.0.0",
-    "iron-resizable": "PolymerElements/iron-resizable-behavior#^1.0.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "iron-pages": "PolymerElements/iron-pages#^1.0.0",

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-resizable/iron-resizable-behavior.html">
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="classlist-shim.html">
 
 <!--

--- a/paper-time-picker.html
+++ b/paper-time-picker.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-media-query/iron-media-query.html">
-<link rel="import" href="../iron-resizable/iron-resizable-behavior.html">
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/typography.html">


### PR DESCRIPTION
I noticed that we have two bower_component folders for the same thing: `bower_components/iron-resizable/` and `bower_components/iron-resizable-behavior/`. I think `paper-time-picker` should import `iron-resizable` in the same manner that other components import it.

Possible maybe kind of sort of related to #44.