### PR TITLE
Fixed clockhand rotation transform for IE11, Edge and Opera browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-time-picker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "authors": [
     "Ben Davis <bendavis78@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-time-picker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Provides a responsive time picker based on the material design spec",
   "main": "index.html",
   "devDependencies": {

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -101,9 +101,9 @@
     (function(){
       var SVG_NS = 'http://www.w3.org/2000/svg';
 
-      var ANIMATION_TRANSITION_TIME = 150; // in milliseconds
+      var RADIANS_PER_DEGREE = Math.PI / 180;
 
-      var ANIMATION_FRAME_DATA_ATTRIBUTE = "paperClockAnimationFrame";
+      var ANIMATION_DURATION = 150; // in milliseconds
 
       // radius values as a percentage of the clock-face radius
       var MAX_VISIBLE = 12;
@@ -158,23 +158,7 @@
           animated: {
             type: Boolean,
             value: false
-          },
-          _currentAngle : {
-            type : Number,
-            value : 0
-          },
-          _rotationOriginX : {
-            type : Number,
-            value : 0
-          },
-          _rotationOriginY : {
-            type : Number,
-            value : 0
-          },
-          _instanceId : Number
-
-          // store absolute positions in _handX and _handY
-          // remove all uses of CSS transforms for rotation, replace with _handX and _handY calcs
+          }
         },
         listeners: {
           'iron-resize': '_updateSize'
@@ -187,6 +171,7 @@
           Polymer.IronResizableBehavior
         ],
         ready: function() {
+          this._currentAngle = 0;
           this._populate();
           this._selectedChanged(this.selected);
           this._instanceId = instanceCount++;
@@ -200,35 +185,30 @@
           var current = this._currentAngle;
           var rotate = getShortestAngle(current, deg);
           if (normalizeAngle(rotate) === current) {
-            return this._setHandRotation(current);
+            return this._setHandRotation(current, animate);
           }
 
-          if (!animate) {
-            return this._setHandRotation(rotate); 
+          if (animate) {
+            this._once('paper-clock-transition-end', function() {
+              if (callback) {
+                callback();
+              }
+            }.bind(this));
           }
-
-          this._once('paper-clock-transition-end', function() {
-            if (callback) {
-              callback();
-            }
-          }.bind(this), this.$.clockHand);
 
           this.async(function() {
-            this._setHandRotation(rotate);
+            this._setHandRotation(rotate, animate);
           });
-
         },
-
-        _performRotation : function(el, angle) {
+        _performRotation : function(angle, animate) {
           // If the angle is in transition from a previous animation, cancel it
-          var animationFrame = el.getAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE);
-          if (animationFrame) {
-            window.cancelAnimationFrame(animationFrame);
+          if (this._animationFrame) {
+            window.cancelAnimationFrame(this._animationFrame);
           }
 
-          // If the element is animated, create an animation loop to transition between the current angle
-          // and the new value.
-          if (this.animated) {
+          // If the transition is animated, create an animation loop that will 
+          // gradually increment towards the new angle while refreshing the hand positions
+          if (animate) {
             var previousAngle = this._currentAngle;
             var angleDifference = angle - previousAngle;
           
@@ -240,39 +220,34 @@
 
               // Calculate the angle of rotation for this frame and apply it to the element
               var elapsedTime = timestamp - animationStart;
-              var animationProgress = Math.min(elapsedTime / ANIMATION_TRANSITION_TIME, 1);
+              var animationProgress = Math.min(elapsedTime / ANIMATION_DURATION, 1);
               this._currentAngle = previousAngle + (this._applyAnimationEasing(animationProgress) * angleDifference);
               this._updateHandPositions();
 
               // If the animation hasn't completed, request animation of the next frame
-              if (animationProgress < 1) {
-                el.setAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE, window.requestAnimationFrame(incrementAngle));
-              }
-              else {
-                el.removeAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE);
+              if (animationProgress === 1) {
+                this._animationFrame = null;
                 this.fire('paper-clock-transition-end');
+              } else {
+                  this._animationFrame = window.requestAnimationFrame(incrementAngle);
               }
             }.bind(this);
 
             // Begin the animation loop by requesting the first frame
-            el.setAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE, window.requestAnimationFrame(incrementAngle));
-          }
-          else {
-            // If the element is not animated, set the transform immediately
+            this._animationFrame = window.requestAnimationFrame(incrementAngle);
+          } else {
+            // If the transition is not animated, set the end angle immediately
             this._currentAngle = angle;
             this._updateHandPositions();
           }
         },
-
         _applyAnimationEasing : function(progress) {
           return Math.pow(progress, 2);
         },
-
-        _setHandRotation: function(deg) {
+        _setHandRotation: function(deg, animate) {
           var hasLabel = ((deg / 360) * this.count) % this.step === 0 ;
           this.$.clockHand.classList[['remove', 'add'][+hasLabel]]('no-dot');
-          this._performRotation(this.$.clockHand, deg);
-          this._performRotation(this.$.clipCircle, deg);
+          this._performRotation(deg, animate);
         },
         _selectedChanged: function(selected) {
           if (!this.count || isNaN(selected)) {
@@ -401,7 +376,6 @@
           this._resizedCache = this._radius;
           this.$.clock.style.width = (radius * 2) + 'px';
           this.$.clock.style.height = (radius * 2) + 'px';
-          this._rotationOriginX = this._rotationOriginY = radius;
           this._updateHandPositions();
 
           this.async(function() {
@@ -417,17 +391,17 @@
 
           this._selectorOuter = this._radius - this._padding * 2;
           this._selectorInner = this._selectorOuter - this._selectorSize * 2;
-          var selectorCenter = this._selectorOuter - this._selectorSize;
+          this._selectorCenter = this._selectorOuter - this._selectorSize;
 
           var numbers = this._numbers;
-          var angle = (360 / this.count) * (Math.PI / 180);
+          var angle = (360 / this.count) * RADIANS_PER_DEGREE;
 
           var a, number;
           for (var i=0; i<this.count; i++) {
             a = angle * i;
             number = numbers[i];
-            number.x = this._radius + (Math.sin(a) * selectorCenter);
-            number.y = this._radius - (Math.cos(a) * selectorCenter);
+            number.x = this._radius + (Math.sin(a) * this._selectorCenter);
+            number.y = this._radius - (Math.cos(a) * this._selectorCenter);
             this._updateNumber(number);
           }
         },
@@ -460,19 +434,20 @@
           }
 
           /* don't animate while tracking */
-          this.animated = event.type !== 'track';
+          var animated = this.animated && event.type !== 'track';
 
           // use coords to find angle from 12 o'clock position
           var theta = Math.atan(y / x);
           theta = (Math.PI / 2) + (x < 0 ? theta + Math.PI : theta);
-          var intervalRad = (360 / this.count) * (Math.PI / 180);
+          var intervalRad = (360 / this.count) * RADIANS_PER_DEGREE;
+
 
           // determine the selected number
           this.selected = Math.round(theta / intervalRad);
 
           /* only fire selected when we've tapped or stopped tracking */
           if (event.type === 'tap' || event.detail.state === 'end') {
-            this.fire('paper-clock-selected', {value: this.selected, animated: this.animated});
+            this.fire('paper-clock-selected', {value: this.selected, animated: animated});
           }
         },
         _formatNumber: function(value) {
@@ -510,13 +485,13 @@
         },
 
         _updateHandPositions : function() {
-          var radiansFrom12 = (this._currentAngle * Math.PI / 180) - (Math.PI / 2);
-          var originX = this._rotationOriginX;
-          var originY = this._rotationOriginY;
-          var handLength = originY - this._numbers[0].y; // distance between the middle of the clock and the 12th hour
+          if (!this._radius) {
+            return;
+          }
 
-          this._handX = originX + (handLength * Math.cos(radiansFrom12));
-          this._handY = originY + (handLength * Math.sin(radiansFrom12));
+          var radians = this._currentAngle * RADIANS_PER_DEGREE;
+          this._handX = this._radius + (Math.sin(radians) * this._selectorCenter);
+          this._handY = this._radius - (Math.cos(radians) * this._selectorCenter);
         },
 
       });

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -434,7 +434,7 @@
           }
 
           /* don't animate while tracking */
-          var animated = this.animated && event.type !== 'track';
+          this.animated = event.type !== 'track';
 
           // use coords to find angle from 12 o'clock position
           var theta = Math.atan(y / x);
@@ -447,7 +447,7 @@
 
           /* only fire selected when we've tapped or stopped tracking */
           if (event.type === 'tap' || event.detail.state === 'end') {
-            this.fire('paper-clock-selected', {value: this.selected, animated: animated});
+            this.fire('paper-clock-selected', {value: this.selected, animated: this.animated});
           }
         },
         _formatNumber: function(value) {

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -79,10 +79,6 @@
         cursor: pointer;
         fill-opacity: 0;
       }
-      #clock.animating #clockHand, 
-      #clock.animating #clipCircle {
-        transition: transform 150ms ease-in;
-      }
     </style>
     <svg version="1.1" id="clock">
       <defs>
@@ -105,6 +101,10 @@
   <script>
     (function(){
       var SVG_NS = 'http://www.w3.org/2000/svg';
+
+      var ANIMATION_TRANSITION_TIME = 150; // in milliseconds
+
+      var ANIMATION_FRAME_DATA_ATTRIBUTE = "paperClockAnimationFrame";
 
       // radius values as a percentage of the clock-face radius
       var MAX_VISIBLE = 12;
@@ -158,7 +158,7 @@
             type: Boolean,
             value: false
           },
-          _rotationAngle : {
+          _currentAngle : {
             type : Number,
             value : 0
           },
@@ -191,41 +191,78 @@
           animate = typeof(animate) === 'undefined' ? this.animated : animate;
           animate = this._radius ? animate : false;
 
-          this.$.clock.classList.remove('animating');
-
-          var current, transform = this._rotationAngle;
+          var current = this._currentAngle;
           var rotate = getShortestAngle(current, deg);
           if (normalizeAngle(rotate) === current) {
             return this._setHandRotation(current);
           }
 
           if (!animate) {
-            return this._setHandRotation(rotate);
+            return this._setHandRotation(rotate); 
           }
 
           this._once(this._transitionEvent, function() {
             if (callback) {
               callback();
             }
-            this.$.clock.classList.remove('animating');
             this.fire('paper-clock-transition-end');
           }.bind(this), this.$.clockHand);
 
-          this.$.clock.classList.add('animating');
           this.async(function() {
             this._setHandRotation(rotate);
           });
 
         },
-        _updateRotationTransform : function(el) {
-           el.setAttribute("transform", "rotate(" + this._rotationAngle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
+
+        _setTransform : function(el, angle) {
+          // If the angle is in transition from a previous animation, cancel it
+          var animationFrame = el.getAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE);
+          if (animationFrame) {
+            window.cancelAnimationFrame(animationFrame);
+          }
+
+          // If the element is animated, create an animation loop to transition between the current angle
+          // and the new value.
+          if (this.animated) {
+            var previousAngle = this._currentAngle;
+            var angleDifference = angle - previousAngle;
+          
+            var animationStart = null;
+            var incrementAngle = function(timestamp) {
+              if (!animationStart) {
+                animationStart = timestamp;
+              }
+
+              // Calculate the angle of rotation for this frame and apply it to the element
+              var elapsedTime = timestamp - animationStart;
+              var animationProgress = Math.min(elapsedTime / ANIMATION_TRANSITION_TIME, 1);
+              this._currentAngle = previousAngle + (this._applyAnimationEasing(animationProgress) * angleDifference);
+              el.setAttribute("transform", "rotate(" + this._currentAngle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
+
+              // If the animation hasn't completed, request animation of the next frame
+              if (animationProgress < 1) {
+                el.setAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE, window.requestAnimationFrame(incrementAngle));
+              }
+            }.bind(this);
+
+            // Begin the animation loop by requesting the first frame
+            el.setAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE, window.requestAnimationFrame(incrementAngle));
+          }
+          else {
+            // If the element is not animated, set the transform immediately
+            el.setAttribute("transform", "rotate(" + angle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
+          }
         },
+
+        _applyAnimationEasing : function(progress) {
+          return Math.pow(progress, 2);
+        },
+
         _setHandRotation: function(deg) {
           var hasLabel = ((deg / 360) * this.count) % this.step === 0 ;
           this.$.clockHand.classList[['remove', 'add'][+hasLabel]]('no-dot');
-          this._rotationAngle = deg;
-          this._updateRotationTransform(this.$.clockHand);
-          this._updateRotationTransform(this.$.clipCircle);
+          this._setTransform(this.$.clockHand, deg);
+          this._setTransform(this.$.clipCircle, deg);
         },
         _selectedChanged: function(selected) {
           if (!this.count || isNaN(selected)) {
@@ -353,8 +390,8 @@
           this.$.clock.style.width = (radius * 2) + 'px';
           this.$.clock.style.height = (radius * 2) + 'px';
           this._rotationOriginX = this._rotationOriginY = radius;
-          this._updateRotationTransform(this.$.clockHand);
-          this._updateRotationTransform(this.$.clipCircle);
+          this._setTransform(this.$.clockHand, this._currentAngle);
+          this._setTransform(this.$.clipCircle, this._currentAngle);
 
           this.async(function() {
             // FIXME: this is hacky, but for some reason we need to wait a bit

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -157,6 +157,18 @@
           animated: {
             type: Boolean,
             value: false
+          },
+          _rotationAngle : {
+            type : Number,
+            value : 0
+          },
+          _rotationOriginX : {
+            type : Number,
+            value : 0
+          },
+          _rotationOriginY : {
+            type : Number,
+            value : 0
           }
         },
         listeners: {
@@ -181,13 +193,7 @@
 
           this.$.clock.classList.remove('animating');
 
-          var current, transform = this._getTransform(this.$.clockHand);
-          if (transform) {
-            current = parseInt(transform.match(/rotate\((-?\d+)deg\)/)[1]);
-          } else {
-            current = 0;
-          }
-
+          var current, transform = this._rotationAngle;
           var rotate = getShortestAngle(current, deg);
           if (normalizeAngle(rotate) === current) {
             return this._setHandRotation(current);
@@ -211,21 +217,15 @@
           });
 
         },
-        _getTransform: function(el) {
-          return el.style.transform | el.style.webkitTransform | el.style.msTransform;
-        },
-        _setTransform: function(el, value) {
-          el.style.msTransform = el.style.webkitTransform = el.style.transform = value;
-        },
-        _setTransformOrigin: function(el, value) {
-          el.style.msTransformOrigin = el.style.webkitTransformOrigin = el.style.transformOrigin = value;
+        _updateRotationTransform : function(el) {
+           el.setAttribute("transform", "rotate(" + this._rotationAngle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
         },
         _setHandRotation: function(deg) {
           var hasLabel = ((deg / 360) * this.count) % this.step === 0 ;
-          var transform = 'rotate(' + deg + 'deg)';
           this.$.clockHand.classList[['remove', 'add'][+hasLabel]]('no-dot');
-          this._setTransform(this.$.clockHand, transform);
-          this._setTransform(this.$.clipCircle, transform);
+          this._rotationAngle = deg;
+          this._updateRotationTransform(this.$.clockHand);
+          this._updateRotationTransform(this.$.clipCircle);
         },
         _selectedChanged: function(selected) {
           if (!this.count || isNaN(selected)) {
@@ -352,9 +352,9 @@
           this._resizedCache = this._radius;
           this.$.clock.style.width = (radius * 2) + 'px';
           this.$.clock.style.height = (radius * 2) + 'px';
-          var v = radius + 'px ' + radius + 'px';
-          this._setTransformOrigin(this.$.clockHand, v);
-          this._setTransformOrigin(this.$.clipCircle, v);
+          this._rotationOriginX = this._rotationOriginY = radius;
+          this._updateRotationTransform(this.$.clockHand);
+          this._updateRotationTransform(this.$.clipCircle);
 
           this.async(function() {
             // FIXME: this is hacky, but for some reason we need to wait a bit

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -73,7 +73,6 @@
       .number text.clipped {
         z-index: 4;
         fill: var(--text-primary-color);
-        clip-path: url('#handClip');
       }
       .select-area {
         cursor: pointer;
@@ -82,7 +81,7 @@
     </style>
     <svg version="1.1" id="clock">
       <defs>
-        <clipPath id="handClip">
+        <clipPath id="handClip[[_instanceId]]">
           <circle id="clipCircle" r$="{{_selectorSize}}" cx$="{{_handX}}" cy$="{{_handY}}"></circle>
         </clipPath>
       </defs>
@@ -109,11 +108,14 @@
       // radius values as a percentage of the clock-face radius
       var MAX_VISIBLE = 12;
 
+      var instanceCount = 0;
+      
       var normalizeAngle = function(a) {
         // convert angle to a positive value between 0 and 360
         a = a ? a % 360 : 0;
         return a < 0 ? a + 360 : a;
       };
+      
       function getShortestAngle(from, to) {
         var angle, offset = 0;
         from = from || 0;
@@ -151,8 +153,7 @@
           },
           zeroPad: {
             type: Boolean,
-            value: false,
-            observer: '_zeroPadChanged'
+            value: false
           },
           animated: {
             type: Boolean,
@@ -169,21 +170,26 @@
           _rotationOriginY : {
             type : Number,
             value : 0
-          }
+          },
+          _instanceId : Number
+
+          // store absolute positions in _handX and _handY
+          // remove all uses of CSS transforms for rotation, replace with _handX and _handY calcs
         },
         listeners: {
           'iron-resize': '_updateSize'
         },
         observers: [
-          '_populate(count, step, useZero)'
+          '_populate(count, step, useZero, _instanceId)',
+          '_zeroPadChanged(zeroPad, _numbers)'
         ],
         behaviors: [
           Polymer.IronResizableBehavior
         ],
         ready: function() {
-          this._transitionEvent = this.style.WebkitTransition ? 'transitionEnd' : 'webkitTransitionEnd';
           this._populate();
           this._selectedChanged(this.selected);
+          this._instanceId = instanceCount++;
         },
         setClockHand: function(deg, animate, callback) {
           deg = normalizeAngle(deg);
@@ -201,11 +207,10 @@
             return this._setHandRotation(rotate); 
           }
 
-          this._once(this._transitionEvent, function() {
+          this._once('paper-clock-transition-end', function() {
             if (callback) {
               callback();
             }
-            this.fire('paper-clock-transition-end');
           }.bind(this), this.$.clockHand);
 
           this.async(function() {
@@ -214,7 +219,7 @@
 
         },
 
-        _setTransform : function(el, angle) {
+        _performRotation : function(el, angle) {
           // If the angle is in transition from a previous animation, cancel it
           var animationFrame = el.getAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE);
           if (animationFrame) {
@@ -237,11 +242,15 @@
               var elapsedTime = timestamp - animationStart;
               var animationProgress = Math.min(elapsedTime / ANIMATION_TRANSITION_TIME, 1);
               this._currentAngle = previousAngle + (this._applyAnimationEasing(animationProgress) * angleDifference);
-              el.setAttribute("transform", "rotate(" + this._currentAngle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
+              this._updateHandPositions();
 
               // If the animation hasn't completed, request animation of the next frame
               if (animationProgress < 1) {
                 el.setAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE, window.requestAnimationFrame(incrementAngle));
+              }
+              else {
+                el.removeAttribute(ANIMATION_FRAME_DATA_ATTRIBUTE);
+                this.fire('paper-clock-transition-end');
               }
             }.bind(this);
 
@@ -250,7 +259,8 @@
           }
           else {
             // If the element is not animated, set the transform immediately
-            el.setAttribute("transform", "rotate(" + angle + " " + this._rotationOriginX + " " + this._rotationOriginY + ")");
+            this._currentAngle = angle;
+            this._updateHandPositions();
           }
         },
 
@@ -261,8 +271,8 @@
         _setHandRotation: function(deg) {
           var hasLabel = ((deg / 360) * this.count) % this.step === 0 ;
           this.$.clockHand.classList[['remove', 'add'][+hasLabel]]('no-dot');
-          this._setTransform(this.$.clockHand, deg);
-          this._setTransform(this.$.clipCircle, deg);
+          this._performRotation(this.$.clockHand, deg);
+          this._performRotation(this.$.clipCircle, deg);
         },
         _selectedChanged: function(selected) {
           if (!this.count || isNaN(selected)) {
@@ -329,6 +339,7 @@
           }
           this.set('_numbers', numbers);
           this._positionClockPoints();
+          this._updateHandPositions();
         },
         _updateNumber: function(number) {
           var dom = number.dom;
@@ -370,6 +381,7 @@
             g.appendChild(text);
             textClipped = create('text', ['clipped']);
             textClipped.textContent = number.label;
+            textClipped.setAttribute("clip-path", "url(#handClip" + this._instanceId + ")");
             g.appendChild(textClipped);
           }
 
@@ -390,8 +402,7 @@
           this.$.clock.style.width = (radius * 2) + 'px';
           this.$.clock.style.height = (radius * 2) + 'px';
           this._rotationOriginX = this._rotationOriginY = radius;
-          this._setTransform(this.$.clockHand, this._currentAngle);
-          this._setTransform(this.$.clipCircle, this._currentAngle);
+          this._updateHandPositions();
 
           this.async(function() {
             // FIXME: this is hacky, but for some reason we need to wait a bit
@@ -419,8 +430,6 @@
             number.y = this._radius - (Math.cos(a) * selectorCenter);
             this._updateNumber(number);
           }
-          this._handX = this._numbers[0].x;
-          this._handY = this._numbers[0].y;
         },
         _notifyNumberChanged: function(path) {
           var propPath, props = ['x', 'y'];
@@ -498,7 +507,18 @@
             callback.apply(null, arguments);
           }
           node.addEventListener(eventName, onceCallback);
-        }
+        },
+
+        _updateHandPositions : function() {
+          var radiansFrom12 = (this._currentAngle * Math.PI / 180) - (Math.PI / 2);
+          var originX = this._rotationOriginX;
+          var originY = this._rotationOriginY;
+          var handLength = originY - this._numbers[0].y; // distance between the middle of the clock and the 12th hour
+
+          this._handX = originX + (handLength * Math.cos(radiansFrom12));
+          this._handY = originY + (handLength * Math.sin(radiansFrom12));
+        },
+
       });
     })();
   </script>


### PR DESCRIPTION
Replaced the transform and transform-origin CSS attributes with position bindings to add compatibility with IE11, Edge and Opera browsers, and to fix the issues raised in #29.

As part of the fixes made for #29, the clip path element has also been given a uniquely generated ID, as the url look-up done by the clip-path attribute and CSS property are global instead of being scoped to an instance of the element. In Firefox, this causes the clip-path attribute on the minutes and seconds numbers to reference the clipPath defined in the hours clock selector, which is hidden at the time they are visible, and will therefore cause all of the numbers to appear clipped.